### PR TITLE
Fix downloader error handling

### DIFF
--- a/util/downloader/downloader_test.go
+++ b/util/downloader/downloader_test.go
@@ -64,15 +64,6 @@ func TestDownloader(t *testing.T) {
 		}
 	}()
 
-	go func() {
-		for err := range downloader.Errors() {
-			assert.Fail(t, "Download encountered an error", err)
-			done <- true
-
-			return
-		}
-	}()
-
 	select {
 	case <-done:
 	case <-time.After(2 * time.Minute):


### PR DESCRIPTION
## Summary
- remove `errCh` and manage failures with logger
- ensure the stats channel closes safely
- update downloader test

## Testing
- `go test ./util/downloader -run TestDownloader -count=1`
- `go test ./... -count=1` *(fails: couldn't run all due to environment)*
